### PR TITLE
Add RemoteIpValve to Tomcat

### DIFF
--- a/server.xml
+++ b/server.xml
@@ -141,6 +141,9 @@
         <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
                resourceName="UserDatabase"/>
       </Realm>
+      
+      <Valve className="org.apache.catalina.valves.RemoteIpValve"
+             protocolHeader="X-Forwarded-Proto"/>
 
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">


### PR DESCRIPTION
This allows a Sync Endpoint behind a reverse proxy to properly determine the http scheme used. 